### PR TITLE
Omstrukturering av kjerneprogrammet fra fem til syv søyler

### DIFF
--- a/kjerneprogram.md
+++ b/kjerneprogram.md
@@ -1,12 +1,10 @@
-# Piratpartiets kjerneprogram 2016
+# Piratpartiets kjerneprogram 2017
 
-## Grunnlag, demokrati og politikk
+## Grunnlag for piratpolitikk
 
 > Piratpartiet tilbyr ikke ferdige løsninger, men metodene for å finne dem.
 
-Piratpartiets kjerneprogram er bygd opp i tre lag:
-
-# Menneskerettigheter og borgerrettigheter
+### Menneskerettigheter og borgerrettigheter
 
 Piratpartiet går inn for både vern og styrking av grunnleggende rettigheter. Utvidelser av våre borgerrettigheter skal ha som mål å styrke andre rettigheter. Rettigheter vi har i dag må voktes over og bevares slik at de ikke svekkes for fremtiden og kommende generasjoner. Piratpartiet mener at borgerrettigheter tilhører individer, og at enhver persons rettigheter er likestilte og like sterke.
 
@@ -16,38 +14,58 @@ Piratpartiet vil stadfeste grunnleggende rettigheter, tilpasset informasjonsalde
 - Kollektive rettigheter, som arbeiderrettigheter og forbrukerrettigheter.
 - Infrastruktur for samhandling, som transport, kommunikasjon og betalingsformidling.
 
-### Demokrati og politikk
+### Inkluderende demokrati
 
 Demokratiets verdier ligger i å sikre frihet. Når demokratiet ikke gjør det, mister systemet sin legitimitet.
 
-Piratpartiet vil etablere demokratiske spilleregler som er tilpasset informasjonsalderen.
+Piratpartiet vil etablere demokratiske spilleregler som er tilpasset informasjonsalderen. Internett gir muligheter til nye og bedre måter å organisere de politiske prosessene for best mulig å representere folkets interesser.
 
 Piratpartiet vil at borgere skal ha tilgang til all relevant informasjon for å kunne ta informerte beslutninger, og for å utføre nødvendig tilsyn med statsadministrasjonen. Uten åpenhet er det ikke ekte demokrati.
 
-Internett gir muligheter til nye og bedre måter å organisere de politiske prosessene for best mulig å representere folkets interesser.
+Piratpartiet legger vekt på at enkeltpersoner skal kunne ta informerte valg og tenke kritisk. Dette innebærer at pirater skaper sin egen politikk utfra fakta og kunnskap som er samlet, uavhengig av hvorvidt avgjørelsen virker korrekt eller ikke i utgangspunktet. Piratpartiets posisjon er ikke basert på meningene til dem som er deres ansikt utad. Tidligere avgjørelser gjort av Piratpartiet er alltid åpne for endringer.
 
-Piratpartiet legger vekt på at enkeltpersoner skal kunne ta informerte valg og tenke kritisk. Dette innebærer at pirater skaper sin egen politikk ut fra fakta og kunnskap som er samlet, uavhengig av hvorvidt avgjørelsen virker korrekt eller ikke i utgangspunktet. Piratpartiets posisjon er ikke basert på meningene til dem som er deres ansikt utad.
+En enkeltpersons rett til å være informert skal aldri forhindres. Piratpartiet mener at alle har en ubegrenset rett til å være involvert i beslutninger som angår dem og deres anliggender. Denne retten garanteres gjennom en styrking av demokratiet og økt åpenhet i politikk og forvaltning. Piratpartiet mener vi trenger en desentralisering av makt, og at demokratiet må styrkes i alle mulige former. Dette ønsker vi å gjøre med en demokratisk reform, der innbyggerne raskt og effektivt kan gi sine folkevalgte og forvaltningen sin mening i alle saker som angår dem. I dagens informasjonssamfunn er dette en samfunnsutvikling den teknologiske utviklingen kommer til å føre til, og Piratpartiet mener det ikke finnes noen grunn til å stritte imot nettets demokratisering av samfunnet.
 
-Tidligere avgjørelser gjort av Piratpartiet er alltid åpne for endringer.
+### Våre sju søyler
 
-En enkeltpersons rett til å være informert skal aldri forhindres.
+Våre prinsipper og standpunkter er organisert i sju søyler:
 
-Piratpartiet mener at alle har en ubegrenset rett til å være involvert i beslutninger som angår dem og deres anliggender. Denne retten garanteres gjennom en styrking av demokratiet og økt åpenhet i politikk og forvaltning. Piratpartiet mener vi trenger en desentralisering av makt, og at demokratiet må styrkes i alle mulige former. Dette ønsker vi å gjøre med en demokratisk reform, der innbyggerne raskt og effektivt kan gi sine folkevalgte og forvaltningen sin mening i alle saker som angår dem. I dagens informasjonssamfunn er dette en samfunnsutvikling den teknologiske utviklingen kommer til å føre til, og Piratpartiet mener det ikke finnes noen grunn til å stritte imot nettets demokratisering av samfunnet.
-
-### Våre fem søyler
-
-Våre prinsipper og standpunkter er organisert i fem søyler:
-
-- individ og personvern
-- demokrati
-- kommunikasjon og infrastruktur
-- kunnskap og kultur
-- teknologi, innovasjon og vitenskap
-
+- Demokrati og samfunn
+- Individ og personvern
+- Kommunikasjon og infrastruktur
+- Kunnskap og kultur
+- Forskning og innovasjon
+- Utdanning
+- Næringsliv og økonomi
 
 I hver søyle beskriver vi prinsippene våre og konkrete politiske standpunkter.
 
-## Individ og personvern
+## 1. Demokrati og samfunn
+
+> Internett muliggjør et styresett som er nærmere det demokratiske idealet enn det vi har i dag.
+
+### Prinsipper
+
+Det representative demokratiet vi har i Norge i dag er ikke den beste måten å oppnå intensjonen om folkestyre. Piratpartiet mener at Internett muliggjør et styresett som tillater borgere å være langt mer involvert i prosessene. Vi har sett tilfeller der særinteresser har hatt utilbørlig innflytelse på politikken, og det ønsker vi å endre. Åpenhet og innsyn, folkeavstemninger og felles utforming av lover vil endre norsk politikk dramatisk, hvor folket igjen bestemmer.
+
+Piratpartiet vil at borgere skal ha tilgang til all relevant informasjon for å kunne ta informerte beslutninger, og for å utføre nødvendig tilsyn med statsadministrasjonen. Uten åpenhet har vi ikke ekte demokrati. I fravær av demokrati kan vi ikke ta avgjørelser om offentlige ressurser, vi kan ikke hindre korrupsjon, og enkeltpersoner kan ikke holdes ansvarlig. Piratpartiet vil opprette en egen organisasjon for å bekjempe korrupsjon i offentlig sektor med rapportering til justisminister.
+
+I den grad private aktører skal forvalte myndighet på vegne av det offentlige, må det stilles samme krav til offentligrettslige saksbehandlingsprinsipp og krav til god forvaltningsskikk.
+
+### Piratpartiet vil konkret
+
+- Gjøre offentlige postjournaler tilgjengelig på Internett uten å måtte be om innsyn.
+- Kreve at kontrakter mellom det offentlige og private publiseres åpent.
+- Publisere offentlige data med gjenbrukbar lisens, bare personvern og rikets sikkerhet kan stanse publisering.
+- Innføre 3-dagersfrist på innsyn etter Offentleglova. Fylkesmannen skal ilegge dagbøter etter 5 dager ved overtredelse.
+- Kreve at digitale 3D-modeller vedlegges byggesøknader med ansvarsrett (tiltak uten ansvarsrett kan søkes uten 3D-modeller).
+- Innføre rådgivende nettbaserte avstemninger i alle landets kommuner og fylkeskommuner. Internett gjør det mulig å forenkle avstemninger uten uforholdsmessig stor ressursbruk.
+- La vanlige folk få legge frem forslag som Stortinget må ta stilling til dersom det oppnås et gitt antall signaturer (elektronisk).
+- Støtte «Holder de ord» og tilsvarende organisasjoner som registrerer hva de politiske partiene mener og hvordan de stemmer på Stortinget.
+- Straffeforfølge korrupsjon i offentlig sektor 20 år tilbake i tid.
+- Fjerne generell bevæpning av politiet.
+
+## 2. Individ og personvern
 
 > Piratpartiet vil bevare de grunnleggende rettighetene alle individer har, jamfør Piratkodeksen.
 
@@ -77,16 +95,18 @@ Vi mener også at infrastrukturene skal være distribuerte, nøytrale og allment
 - Gjøre kildevernet absolutt.
 - Styrke ytrings- og varslingsfrihet. Gjengjeldelse fra arbeidsgiver straffes med fengsel i inntil seks år.
 
-## Kommunikasjon og infrastruktur
+## 3. Kommunikasjon og infrastruktur
 
 > Åpne, velutbygde og nøytrale infrastrukturer er en forutsetning for at individet skal kunne samhandle med samfunnet.
 
 ### Prinsipper
 Kommunikasjon er selve livsnerven for et fungerende moderne samfunn enten det er personer som skal reise, varer som skal sendes, tanker som skal utveksles eller informasjon som skal deles.
 
-For at kommunikasjonen skal tjene formålet med å koble sammen individer, må infrastrukturen både være velutbygd og nøytral. Hverken Vegvesenet, postverket eller nettleverandørene skal diktere hvordan infrastrukturen skal benyttes.
-
 Å kunne jobbe for et enda mer effektivt demokrati og fremgangsrikt samfunn forutsetter tanke- og ytringsfrihet. Det krever at folket skal kunne kommunisere fritt uten sensur og overvåkning, hverken fra det offentlige eller fra private.
+
+I den vestlige verden har opphavsrett blitt en alvorlig trussel mot fri kommunikasjon, uavhengig om folk gjør noe lovlig eller ulovlig. Opphavsrett blitt brukt for å rettferdiggjøre sensur, spionasje og innføring av restriksjoner på Internett. Piratpartiet er ikke imot opphavsrett, men det er åpenbart behov for å oppdaterte lovverket.
+
+For at kommunikasjonen skal tjene formålet med å koble sammen individer, må infrastrukturen både være velutbygd og nøytral. Hverken Vegvesenet, postverket eller nettleverandørene skal diktere hvordan infrastrukturen skal benyttes.
 
 ### Piratpartiet vil konkret
 
@@ -102,38 +122,9 @@ For at kommunikasjonen skal tjene formålet med å koble sammen individer, må i
 - Begrense lengden på KID-nummer for å hindre unødig frustrasjon ved betaling av regninger.
 - Påby maskinlesbar strekkode på giro som alternativ til KID-nummer.
 
+## 4. Kunnskap og kultur
 
-## Demokrati
-
->   Internett muliggjør et styresett som er nærmere det demokratiske idealet enn det vi har i dag.
-
-### Prinsipper
-Det representative demokratiet vi har i Norge i dag er ikke den beste måten å oppnå intensjonen om folkestyre. Piratpartiet mener at Internett muliggjør et styresett som tillater borgere å være langt mer involvert i prosessene. Vi har sett tilfeller der særinteresser har hatt utilbørlig innflytelse på politikken, og det ønsker vi å endre. Åpenhet og innsyn, folkeavstemninger og felles utforming av lover vil endre norsk politikk dramatisk, hvor folket igjen bestemmer.
-
-Piratpartiet vil at borgere skal ha tilgang til all relevant informasjon for å kunne ta informerte beslutninger, og for å utføre nødvendig tilsyn med statsadministrasjonen. Uten åpenhet har vi ikke ekte demokrati. I fravær av demokrati kan vi ikke ta avgjørelser om offentlige ressurser, vi kan ikke hindre korrupsjon, og enkeltpersoner kan ikke holdes ansvarlig. Piratpartiet vil opprette en egen organisasjon for å bekjempe korrupsjon i offentlig sektor med rapportering til justisminister.
-
-Piratpartiet vil sikre låntakere mot verdifall i bolig, og la låntaker betale sitt boliglån ved å overføre eiendommen til banken. Utlån og avgifter skal være faste slik at låntakere kan endre sine låneinstitusjoner dersom de ønsker det, på samme måte som en bytter bank. Slik kan vi etablere et normalt forbrukermarked. Gjeldsordningsloven må forenkles med raskere sletting av gjeld. Folk skal ikke slås konkurs på grunn av økonomisk kollaps forårsaket av deres utlåner.
-
-Store bedrifter har fått altfor mye oppmerksomhet de siste årene. Bedrifter med færre enn 100 ansatte utgjør 99 % av norsk næringsliv. Over 1 million arbeider i små og mellomstore bedrifter. Piratpartiet ønsker å forbedre forholdene for små og mellomstore bedrifter med forenklet rammeverk. Piratpartiet vil se på mulighetene som internett- og delingsøkonomien gir.
-
-I den grad private aktører skal forvalte myndighet på vegne av det offentlige, må det stilles samme krav til offentligrettslige saksbehandlingsprinsipp og krav til god forvaltningsskikk.
-
-### Piratpartiet vil konkret
-
-- Gjøre offentlige postjournaler tilgjengelig på Internett uten å måtte be om innsyn.
-- Publisere offentlige data med gjenbrukbar lisens, bare personvern og rikets sikkerhet kan stanse publisering.
-- Støtte «Holder de ord» og tilsvarende organisasjoner som registrerer hva de politiske partiene mener og hvordan de stemmer på Stortinget.
-- Innføre rådgivende nettbaserte avstemninger i alle landets kommuner og fylkeskommuner. Internett gjør det mulig å forenkle avstemninger uten uforholdsmessig stor ressursbruk.
-- Kreve at digitale 3D-modeller vedlegges byggesøknader med ansvarsrett (tiltak uten ansvarsrett kan søkes uten 3D-modeller).
-- Kreve at kontrakter mellom det offentlige og private publiseres åpent.
-- La vanlige folk få legge frem forslag som Stortinget må ta stilling til dersom det oppnås et gitt antall signaturer (elektronisk).
-- Innføre 3-dagersfrist på innsyn etter offentleglova. Fylkesmannen skal ilegge dagbøter etter 5 dager ved overtredelse.
-- Fjerne generell bevæpning av politiet.
-- Straffeforfølge korrupsjon i offentlig sektor 20 år tilbake i tid.
-
-## Kunnskap og kultur
-
->   Piratpartiet ønsker at samfunnet får tilgang til mest mulig kunnskap og kultur, og ønsker at fagfellevurdert forskning skal avdekke virkemidler som gir oss det samfunnet vi ønsker.
+> Piratpartiet ønsker at samfunnet får tilgang til mest mulig kunnskap og kultur, og ønsker at fagfellevurdert forskning skal avdekke virkemidler som gir oss det samfunnet vi ønsker.
 
 ### Prinsipper
 
@@ -142,26 +133,21 @@ Opphavsrett var opprinnelig ment som et midlertidig monopol for å stimulere til
 ### Piratpartiet vil konkret
 
 - Avkriminalisere privat og ikke-kommersiell deling av åndsverk, siden håndheving av slike forbud nødvendigvis må medføre et overvåkningssamfunn.
-- Kreve at offentlig finansiert forskning må publiseres åpent og være fritt tilgjengelig.
-- Fjerne programvarepatenter og biologiske patenter. Patenter på andre områder vurderes etter nytteverdi for befolkningen.
-- Opprettholde støtteordninger for kreative og kunstneriske aktiviteter.
-- Kreve at kulturinstitusjoner, som får offentlig støtte, publiserer gjenbrukbart digitalt innhold.
-- Kreve bruk av fri programvare i offentlig sektor dersom dette er mulig.
 - Redusere vernetiden for åndsverk til maksimalt 20 år etter utgivelse og innføre enkle krav om registrering etter 5 år.
 - Bortfall av vernetid ved manglende produksjon/utgivelse av åndsverk.
 - Innføre leserett for innhold med kopisperrer.
 - Bekjempe spesialavgifter på lagringsmedier.
 - Gi rett til å utvikle ikke-kommersiell kultur basert på kommersielle produkter.
 - Foreslå at «fair use» tas inn i lovverket som en beskyttelse av privatpersoners rett til å skape egne kulturuttrykk med elementer fra eksisterende verk.
-- Unngå særbehandling av enkelte produktleverandører i skoleverket og det offentlige.
-- Støtte Nasjonal digital læringsarena (NDLA) som gjør skolemateriell fritt tilgjengelig på nett.
-- Innføre krav om at offentlig ansatte skal bidra med gjenbrukbart innhold på nettet i relevante arenaer.
-- Det skal etableres regionalt tilbud om programmering som tilvalgsfag i videregående skoler.
 - Gi Nasjonalbiblioteket økt støtte til digitalisering av eldre aviser, tidsskrifter og andre publikasjoner, slik at de raskt blir lettere tilgjengelig for offentligheten enn i dag.
+- Opprettholde støtteordninger for kreative og kunstneriske aktiviteter.
+- Kreve at kulturinstitusjoner, som får offentlig støtte, publiserer gjenbrukbart digitalt innhold.
+- Innføre krav om at offentlig ansatte skal bidra med gjenbrukbart innhold på nettet i relevante arenaer.
+- Kreve bruk av fri programvare i offentlig sektor dersom dette er mulig.
 
-## Teknologi, innovasjon og vitenskap
+## 5. Forskning og innovasjon
 
->   Piratpartiet tror på forskning, utvikling og deling av resultater.
+> Piratpartiet tror på forskning, utvikling og deling av resultater.
 
 ### Prinsipper
 
@@ -169,19 +155,36 @@ Piratpartiet støtter satsing på teknologi, innovasjon og den vitenskapelige me
 
 Det må være en balanse mellom grunnforskning og resultatorientert forskning. Piratpartiet vil gi universitetene våre en sterkere og mer selvstendig stilling i samfunnet for å hindre at politikere overstyrer og forstyrrer vitenskapelige metoder. Universitetsansatte skal ikke lenger hindres fra å delta i den offentlige debatt.
 
-Patenter, som statlig garanterte monopoler, skaper en kunstig innskrenkning av den allmenne velferden, og trenger hyppig overprøving og evaluering. Programvarepatenter og biologiske patenter er særlig skadelige og bør fjernes. Patenter som direkte blokkerer fremskritt i vitenskap og/eller teknologi bør under alle omstendigheter forhindres.
-
 Forskning som er offentlig finansiert (inkludert rådata, programkode og metoder) skal ligge åpent på Internett. Det tjener ikke samfunnet som helhet at forskning foregår bak lukkede dører uten mulighet for innsyn for andre i rådata, metoder, og programkode som er brukt som grunnlag for konklusjoner i forskningen.
 
-I den vestlige verden har opphavsrett blitt en alvorlig trussel mot fri kommunikasjon, uavhengig om folk gjør noe lovlig eller ulovlig. Opphavsrett blitt brukt for å rettferdiggjøre sensur, spionasje og innføring av restriksjoner på Internett. Piratpartiet er ikke imot opphavsrett, men det er åpenbart behov for å oppdaterte lovverket.
+Patenter, som statlig garanterte monopoler, skaper en kunstig innskrenkning av den allmenne velferden, og trenger hyppig overprøving og evaluering. Programvarepatenter og biologiske patenter er særlig skadelige og bør fjernes. Patenter som direkte blokkerer fremskritt i vitenskap og/eller teknologi bør under alle omstendigheter forhindres.
 
-Piratpartiet mener at utdanningssystemet må oppdateres. Samfunn og utdanningssystemet må være i harmoni fra barnehage til høyere utdanning. Formålet med utdanningssystemet er å lære folk hvordan samfunnet fungerer og hvordan ny kunnskap blir skapt. Altfor mange menneske med høyere utdanning står uten muligheter til å finne arbeid i sitt fagfelt. Dette vil Piratpartiet endre ved å gjøre utdanninger på alle nivå mer varierte, fleksible, koblet til Internett og direkte koblet til samfunnet. Piratpartiet vil også at seksualitet skal være eget fag i grunnskolen, der det blir lagt vekt på gjensidig respekt, kommunikasjon og informert samtykke.
+### Piratpartiet vil konkret
+
+- Øke offentlig støtte til forskning.
+- Kreve at offentlig finansiert forskning må publiseres åpent og være fritt tilgjengelig.
+- Data og programvare finansiert gjennom offentlige midler, helt eller delvis, skal være åpent og fritt tilgjengelig.
+- Fjerne programvarepatenter, medisinske-, og biologiske patenter. Andre typer patenter skal vurderes.
+- Redusere vernetida på patentert miljøvennlig teknologi for å løse fremtidens miljøutfordringer.
+
+## 6. Utdanning
+### Prinsipper
+
+Piratpartiet mener at utdanningssystemet må oppdateres. Samfunn og utdanningssystemet må være i harmoni fra barnehage til høyere utdanning. Formålet med utdanningssystemet er å lære folk hvordan samfunnet fungerer og hvordan ny kunnskap blir skapt. Altfor mange mennesker med høyere utdanning står uten muligheter til å finne arbeid i sitt fagfelt. Dette vil Piratpartiet endre ved å gjøre utdanninger på alle nivå mer varierte, fleksible, koblet til Internett og direkte koblet til samfunnet. Piratpartiet vil også at seksualitet skal være eget fag i grunnskolen, der det blir lagt vekt på gjensidig respekt, kommunikasjon og informert samtykke.
 
 Utdanning skal gi pensjonspoeng. Folk som tar høyere utdanning eller videreutdanning kommer senere ut i arbeidslivet enn de som ikke tar det.
 
 ### Piratpartiet vil konkret
 
-- Øke offentlig støtte til forskning.
-- Fjerne programvarepatenter, medisinske-, og biologiske patenter. Andre typer patenter skal vurderes.
-- Redusere vernetida på patentert miljøvennlig teknologi for å løse fremtidens miljøutfordringer.
-- Data og programvare finansiert gjennom offentlige midler, helt eller delvis, skal være åpent og fritt tilgjengelig.
+- Det skal etableres regionalt tilbud om programmering som tilvalgsfag i videregående skoler.
+- Unngå særbehandling av enkelte produktleverandører i skoleverket og det offentlige.
+- Støtte Norsk Digital Læringsarena (NDLA) som gjør skolemateriell fritt tilgjengelig på nett.
+
+## 7. Næringsliv og økonomi
+### Prinsipper
+
+Store bedrifter har fått altfor mye oppmerksomhet de siste årene. Bedrifter med færre enn 100 ansatte utgjør 99 % av norsk næringsliv. Over 1 million arbeider i små og mellomstore bedrifter. Piratpartiet ønsker å forbedre forholdene for små og mellomstore bedrifter med forenklet rammeverk. Piratpartiet vil se på mulighetene som internett- og delingsøkonomien gir.
+
+Piratpartiet vil sikre låntakere mot verdifall i bolig, og la låntaker betale sitt boliglån ved å overføre eiendommen til banken. Utlån og avgifter skal være faste slik at låntakere kan endre sine låneinstitusjoner dersom de ønsker det, på samme måte som en bytter bank. Slik kan vi etablere et normalt forbrukermarked. Gjeldsordningsloven må forenkles med raskere sletting av gjeld. Folk skal ikke slås konkurs på grunn av økonomisk kollaps forårsaket av deres utlåner.
+
+### Piratpartiet vil konkret


### PR DESCRIPTION
Forslag `Struktur_1-19` av @Kindleguy (endring) til omstrukturering fra fem til syv søyler.

**Begrunnelse:**
Denne omstruktureringa skal gjøre kjerneprogrammet noe ryddigere og lettere å lese. Fem søyler har blitt til sju, slik at ingen søyleseksjoner er mye lengre enn andre. Store lengdeforskjeller på søylene er nemlig et problem, slik det er i dag. Alle punkt fra nåværende program er med i uendra form, men de har i mange tilfeller fått nye plasseringer, og enkelte overskrifter er endra eller lagt til.

I resten av forslaga for kjerneprogrammet, refereres det både til gammel og ny plassering. Hvis omstrukturering blir vedtatt, vil endringer vedtatt i de andre forslagene følge med i de nye plasseringene av programpunktene.