### PR TITLE
Ny introduksjon av Piratpartiets politiske plattform

### DIFF
--- a/kjerneprogram.md
+++ b/kjerneprogram.md
@@ -2,6 +2,8 @@
 
 ## Grunnlag, demokrati og politikk
 
+Piratpartiet mener kunnskap og kultur skal deles og gjenbrukes, at individets rettigheter skal forsvares, og at Internett muliggjør en mer direkte og demokratisk politisk modell.
+
 > Piratpartiet tilbyr ikke ferdige løsninger, men metodene for å finne dem.
 
 Piratpartiets kjerneprogram er bygd opp i tre lag:


### PR DESCRIPTION
Forslag `Stuktur_20` fra @Kindleguy (tillegg) til omstrukturering av introduksjon:

Legg til dette rett etter overskrifta «Grunnlag, demokrati og politikk» (ny struktur: Grunnlag for piratpolitikk) og rett før nåværende setning der:
«Piratpartiet mener kunnskap og kultur skal deles og gjenbrukes, at individets rettigheter skal forsvares, og at Internett muliggjør en mer direkte og demokratisk politisk modell.»
 
Setning er henta ifrå eit gammalt forord til programmet (https://wiki.piratpartiet.no/index.php?title=Piratpartiets_s%C3%B8yler#Piratpartiets_opphav). Har endra ordet «Vi» til «Piratpartiet» og «nettet» til «Internett». Eg synest at akkurat denne setning bør bli ein del av sjølve kjerneprogrammet.