### PR TITLE
Tillegg: Nytt punkt til "Forskning og innovasjon"

### DIFF
--- a/kjerneprogram.md
+++ b/kjerneprogram.md
@@ -189,6 +189,7 @@ Patenter, som statlig garanterte monopoler, skaper en kunstig innskrenkning av d
 
 - Øke offentlig støtte til forskning.
 - Kreve at offentlig finansiert forskning må publiseres i åpent format, være fritt tilgjengelig og kunne brukes fritt.
+- Kreve at offentlig finansiert forskning skal være bygd på vitenskapelige metoder, uten ideologisk eller politisk påvirkning.
 - Data og programvare finansiert gjennom offentlige midler, helt eller delvis, skal benytte seg av fri eller åpen-kildekode-lisenser, og den modifiserte kildekoden må være åpen og fritt tilgjengelig og kunne brukes fritt.
 - Fjerne programvarepatenter, medisinske-, og biologiske patenter. Andre typer patenter skal vurderes.
 - Redusere vernetida på patentert miljøvennlig teknologi for å løse fremtidens miljøutfordringer.


### PR DESCRIPTION
Forslag til søyla "Forskning og innovasjon", seksjon "Piratpartiet vil konkret":

Legg til punktet

"• Kreve at offentlig finansiert forskning skal være bygd på vitenskapelige metoder, uten ideologisk eller politisk påvirkning."

Øyvind Nondal fekk gjennom fjerning av dette punktet frå kjerneprogrammet på landsmøtet i 2016:

https://wiki.piratpartiet.no/Kjerneprogrammet_med_endringsforslag_fra_%C3%98yvind_Nondal (forslag 43)


Kenneth forsøkte å oppdatere formuleringa av dette punktet, slik at det skulle bli vedtatt, men det blei argument for på landsmøtet i 2017 at Polden ikkje hadde laga ei særleg god formulering. Eg vil derfor foreslå å innføre punktet med den originale formuleringa, men er open for forslag til å gjere det betre. Dette punktet er viktig i ei tid der personlege oppfatningar og falske nyheiter får råde i staden for vitskap og fornuft.